### PR TITLE
修复smtp.SMTP_SSL()和starttls()的冲突

### DIFF
--- a/XTestRunner/_email.py
+++ b/XTestRunner/_email.py
@@ -33,7 +33,7 @@ class SMTP(object):
         self.user = user
         self.password = password
         self.host = host
-        self.port = int(port) if port is not None else 465
+        self.port = int(port) if port is not None else (465 if ssl else 587)
         self.ssl = ssl
         self.tls = tls
 
@@ -87,7 +87,7 @@ class SMTP(object):
             msg.attach(att)
 
         smtp = smtplib.SMTP_SSL(self.host, self.port) if self.ssl else smtplib.SMTP(self.host, self.port)
-        if self.tls is True:
+        if self.tls is True and self.ssl is False:
             smtp.starttls()
         try:
             smtp.login(self.user, self.password)


### PR DESCRIPTION
1、使用smtp.SMTP_SSL()之后，不能再调用starttls()。
2、SSL默认端口465，TLS默认端口587