### PR TITLE
feat: Add footer parameter to control whether the footer page display

### DIFF
--- a/XTestRunner/html/template.html
+++ b/XTestRunner/html/template.html
@@ -272,7 +272,7 @@
         return s;
       }
     </script>
-
+    {% if keep_footer %}
     <footer class="footer" style="height: 50px; position: fixed; width: 100%">
       <div class="container-fluid">
         <div class="row">
@@ -282,5 +282,6 @@
         </div>
       </div>
     </footer>
+    {% endif %}
   </body>
 </html>

--- a/XTestRunner/htmlrunner/runner.py
+++ b/XTestRunner/htmlrunner/runner.py
@@ -152,6 +152,7 @@ class HTMLTestRunner(object):
                  rerun=0,
                  language="en",
                  logger=None,
+                 footer=True,
                  **kwargs):
         self.stream = stream
         self.verbosity = verbosity
@@ -184,6 +185,8 @@ class HTMLTestRunner(object):
 
         self.whitelist = set(kwargs.pop('whitelist', []))
         self.blacklist = set(kwargs.pop('blacklist', []))
+
+        self.keep_footer = footer
 
     @classmethod
     def test_iter(cls, suite):
@@ -328,6 +331,7 @@ class HTMLTestRunner(object):
             heading=heading,
             report=report,
             channel=self.run_times,
+            keep_footer=self.keep_footer
         )
         self.stream.write(html_content.encode('utf8'))
 

--- a/tests/test_output_html.py
+++ b/tests/test_output_html.py
@@ -32,4 +32,5 @@ if __name__ == '__main__':
             title='<project name>test report',
             description='describe: ... ',
             language='en',
+            footer=True
         ))


### PR DESCRIPTION
`HTMLTestRunner` 增加 `footer` 参数用于控制是否生成报告页面底部的信息，默认为：`True`
```python
testRunner=HTMLTestRunner(
            stream=fp,
            tester="bugmaster",
            title='<project name>test report',
            description='describe: ... ',
            language='en',
            footer=True
        )
```
相关issue：https://github.com/SeldomQA/XTestRunner/issues/49